### PR TITLE
Update Deno Dependencies

### DIFF
--- a/denops/detect-indent/buffer-cache.ts
+++ b/denops/detect-indent/buffer-cache.ts
@@ -1,7 +1,7 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
-import * as vimVars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
-import { assertLike } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
+import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
+import { assertLike } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import type { Options } from "./options.ts";
 
 const KEY = "detect_indent";

--- a/denops/detect-indent/buffer-cache.ts
+++ b/denops/detect-indent/buffer-cache.ts
@@ -1,16 +1,15 @@
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
-import { assertLike } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import type { Options } from "./options.ts";
+import { isOptions } from "./options.ts";
 
 const KEY = "detect_indent";
 
-type Cache = {
+export type Cache = {
   prev: Options;
 };
-
-const cacheTemplate: Cache = { prev: {} };
 
 export async function get(denops: Denops): Promise<Cache | null> {
   const cache = await vimVars.b.get(denops, KEY);
@@ -30,6 +29,18 @@ function assertCacheOrNull(
   maybeCache: unknown,
 ): asserts maybeCache is Cache | null {
   if (maybeCache !== null) {
-    assertLike(cacheTemplate, maybeCache);
+    assert(maybeCache, isCache);
   }
+}
+
+export function isCache(maybeCache: unknown): maybeCache is Cache {
+  if (!is.Record(maybeCache)) {
+    return false;
+  }
+
+  if ("prev" in maybeCache) {
+    return isOptions(maybeCache.prev);
+  }
+
+  return false;
 }

--- a/denops/detect-indent/calculate.ts
+++ b/denops/detect-indent/calculate.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import type { Options } from "./options.ts";
 import * as logger from "./logger.ts";
 import { isEmptyObject } from "./util.ts";

--- a/denops/detect-indent/detect.ts
+++ b/denops/detect-indent/detect.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import { isDetectable } from "./detectable.ts";
 import { calculate } from "./calculate.ts";
 import * as options from "./options.ts";

--- a/denops/detect-indent/detectable.ts
+++ b/denops/detect-indent/detectable.ts
@@ -2,7 +2,8 @@ import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import { collect } from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
-import { assertArray } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+import type { Predicate } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import * as bufferCache from "./buffer-cache.ts";
 
 export async function isDetectable(denops: Denops): Promise<boolean> {
@@ -20,7 +21,7 @@ async function isValidFiletype(denops: Denops): Promise<boolean> {
       vimOptions.filetype.get(denops),
     ];
   });
-  assertArrayOrNull<string>(ignoreFiletypes);
+  assertArrayOrNull(ignoreFiletypes, is.String);
 
   return ignoreFiletypes == null || !ignoreFiletypes.includes(filetype);
 }
@@ -32,7 +33,7 @@ async function isValidBuftype(denops: Denops): Promise<boolean> {
       vimOptions.buftype.get(denops),
     ];
   });
-  assertArrayOrNull<string>(ignoreBuftypes);
+  assertArrayOrNull(ignoreBuftypes, is.String);
 
   return ignoreBuftypes == null || !ignoreBuftypes.includes(buftype);
 }
@@ -46,8 +47,9 @@ async function isValidCount(denops: Denops): Promise<boolean> {
 
 function assertArrayOrNull<T>(
   maybeArray: unknown,
+  pred: Predicate<T>,
 ): asserts maybeArray is T[] | null {
   if (maybeArray !== null) {
-    assertArray<T>(maybeArray);
+    assert(maybeArray, is.ArrayOf(pred));
   }
 }

--- a/denops/detect-indent/detectable.ts
+++ b/denops/detect-indent/detectable.ts
@@ -1,8 +1,8 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import { collect } from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
-import * as vimVars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
-import { assertArray } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import { collect } from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
+import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
+import { assertArray } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import * as bufferCache from "./buffer-cache.ts";
 
 export async function isDetectable(denops: Denops): Promise<boolean> {

--- a/denops/detect-indent/logger.ts
+++ b/denops/detect-indent/logger.ts
@@ -1,6 +1,6 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import { batch } from "https://deno.land/x/denops_std@v5.0.0/batch/mod.ts";
-import * as vimVars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import { batch } from "https://deno.land/x/denops_std@v5.0.1/batch/mod.ts";
+import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
 
 const HIGHLIGHT_GROUPS_MAP = {
   debug: "Debug",

--- a/denops/detect-indent/main.ts
+++ b/denops/detect-indent/main.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import { detect } from "./detect.ts";
 import { restore } from "./restore.ts";
 

--- a/denops/detect-indent/options.ts
+++ b/denops/detect-indent/options.ts
@@ -1,5 +1,5 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as logger from "./logger.ts";
 import { isEmptyObject } from "./util.ts";
 

--- a/denops/detect-indent/restore.ts
+++ b/denops/detect-indent/restore.ts
@@ -1,4 +1,4 @@
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as bufferCache from "./buffer-cache.ts";
 import * as options from "./options.ts";
 import * as logger from "./logger.ts";

--- a/test/denops/detect-indent/buffer-cache_test.ts
+++ b/test/denops/detect-indent/buffer-cache_test.ts
@@ -4,9 +4,9 @@ import {
   assertEquals,
   assertRejects,
 } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
-import * as vimVars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
+import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
 import * as bufferCache from "../../../denops/detect-indent/buffer-cache.ts";
 
 test({

--- a/test/denops/detect-indent/buffer-cache_test.ts
+++ b/test/denops/detect-indent/buffer-cache_test.ts
@@ -4,39 +4,44 @@ import {
   assertEquals,
   assertRejects,
 } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import { assertType } from "https://deno.land/std@0.192.0/testing/types.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
-import * as bufferCache from "../../../denops/detect-indent/buffer-cache.ts";
+import type { Cache } from "../../../denops/detect-indent/buffer-cache.ts";
+import {
+  get as getBufferCache,
+  isCache,
+  set as setBufferCache,
+} from "../../../denops/detect-indent/buffer-cache.ts";
 
 test({
   mode: "all",
-  name: "bufferCache.get() returns `b:detect_indent` value",
+  name: "get() returns `b:detect_indent` value",
   async fn(denops: Denops) {
-    assertEquals(await bufferCache.get(denops), null);
+    assertEquals(await getBufferCache(denops), null);
 
     const cache = { prev: { expandtab: true, shiftwidth: 2 } };
     await vimVars.b.set(denops, "detect_indent", cache);
 
-    assertEquals(await bufferCache.get(denops), cache);
+    assertEquals(await getBufferCache(denops), cache);
   },
 });
 
 test({
   mode: "all",
-  name:
-    "bufferCache.get() throws an error if `b:detect_indent` value is invalid",
+  name: "get() throws an error if `b:detect_indent` value is invalid",
   async fn(denops: Denops) {
     const cache = { expandtab: true, shiftwidth: 2 };
     await vimVars.b.set(denops, "detect_indent", cache);
 
-    await assertRejects(async () => await bufferCache.get(denops));
+    await assertRejects(async () => await getBufferCache(denops));
   },
 });
 
 test({
   mode: "all",
-  name: "bufferCache.set() sets current options as `b:detect_indent`",
+  name: "set() sets current options as `b:detect_indent`",
   async fn(denops: Denops) {
     const expandtab = await vimOptions.expandtab.getLocal(denops);
     const shiftwidth = await vimOptions.shiftwidth.getLocal(denops);
@@ -44,8 +49,49 @@ test({
 
     assertEquals(await vimVars.b.get(denops, "detect_indent"), null);
 
-    await bufferCache.set(denops);
+    await setBufferCache(denops);
 
     assertEquals(await vimVars.b.get(denops, "detect_indent"), cache);
+  },
+});
+
+Deno.test({
+  name: "isCache() returns true if the argument is a Cache",
+  fn() {
+    const cache = { prev: {} };
+
+    assertType<
+      typeof cache extends Cache ? true : false
+    >(true);
+
+    assertEquals(isCache(cache), true);
+  },
+});
+
+Deno.test({
+  name: "isCache() returns false unless the argument is a Cache",
+  fn() {
+    const empty = {};
+    const withInvalidOptions = {
+      prev: { foo: 42 },
+    };
+    const withUnknownKeys = {
+      prev: { expandtab: 42 },
+      next: true,
+    };
+
+    assertType<
+      typeof empty extends Cache ? true : false
+    >(false);
+    assertType<
+      typeof withInvalidOptions extends Cache ? true : false
+    >(false);
+    assertType<
+      typeof withUnknownKeys extends Cache ? true : false
+    >(false);
+
+    assertEquals(isCache(empty), false);
+    assertEquals(isCache(withInvalidOptions), false);
+    assertEquals(isCache(withUnknownKeys), false);
   },
 });

--- a/test/denops/detect-indent/calculate_test.ts
+++ b/test/denops/detect-indent/calculate_test.ts
@@ -1,8 +1,8 @@
 // Use denops' test() instead of built-in Deno.test()
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import { calculate } from "../../../denops/detect-indent/calculate.ts";
 import * as testHelper from "../test-helper.ts";
 

--- a/test/denops/detect-indent/detect_test.ts
+++ b/test/denops/detect-indent/detect_test.ts
@@ -4,9 +4,9 @@ import {
   assertEquals,
   assertNotEquals,
 } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as bufferCache from "../../../denops/detect-indent/buffer-cache.ts";
 import { detect } from "../../../denops/detect-indent/detect.ts";
 import * as testHelper from "../test-helper.ts";

--- a/test/denops/detect-indent/detectable_test.ts
+++ b/test/denops/detect-indent/detectable_test.ts
@@ -1,6 +1,9 @@
 // Use denops' test() instead of built-in Deno.test()
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import {
+  assertEquals,
+  assertRejects,
+} from "https://deno.land/std@0.192.0/testing/asserts.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
@@ -92,6 +95,40 @@ test({
     await vimVars.g.set(denops, "detect_indent#detect_once", true);
 
     assertEquals(await isDetectable(denops), false);
+  },
+});
+
+test({
+  mode: "all",
+  name:
+    "isDetectable() throws an error if g:detect_indent#ignore_filetypes is not `null` nor `string[]`",
+  async fn(denops: Denops) {
+    await vimOptions.filetype.set(denops, "vim");
+    await vimOptions.buftype.set(denops, "");
+    assertEquals(await bufferCache.get(denops), null);
+
+    await vimVars.g.set(denops, "detect_indent#ignore_filetypes", [42]);
+    await vimVars.g.set(denops, "detect_indent#ignore_buftypes", ["nofile"]);
+    await vimVars.g.set(denops, "detect_indent#detect_once", true);
+
+    await assertRejects(async () => await isDetectable(denops));
+  },
+});
+
+test({
+  mode: "all",
+  name:
+    "isDetectable() throws an error if g:detect_indent#ignore_buftypes is not `null` nor `string[]`",
+  async fn(denops: Denops) {
+    await vimOptions.filetype.set(denops, "vim");
+    await vimOptions.buftype.set(denops, "");
+    assertEquals(await bufferCache.get(denops), null);
+
+    await vimVars.g.set(denops, "detect_indent#ignore_buftypes", ["txt"]);
+    await vimVars.g.set(denops, "detect_indent#ignore_buftypes", [42]);
+    await vimVars.g.set(denops, "detect_indent#detect_once", true);
+
+    await assertRejects(async () => await isDetectable(denops));
   },
 });
 

--- a/test/denops/detect-indent/detectable_test.ts
+++ b/test/denops/detect-indent/detectable_test.ts
@@ -1,9 +1,9 @@
 // Use denops' test() instead of built-in Deno.test()
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
-import * as vimVars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
+import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
 import * as bufferCache from "../../../denops/detect-indent/buffer-cache.ts";
 import { isDetectable } from "../../../denops/detect-indent/detectable.ts";
 

--- a/test/denops/detect-indent/logger_test.ts
+++ b/test/denops/detect-indent/logger_test.ts
@@ -4,10 +4,10 @@ import {
   assertMatch,
   assertNotMatch,
 } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
-import * as vimVars from "https://deno.land/x/denops_std@v5.0.0/variable/mod.ts";
-import { assertString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
+import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
+import { assertString } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import * as logger from "../../../denops/detect-indent/logger.ts";
 
 test({

--- a/test/denops/detect-indent/logger_test.ts
+++ b/test/denops/detect-indent/logger_test.ts
@@ -7,7 +7,7 @@ import {
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";
-import { assertString } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import * as logger from "../../../denops/detect-indent/logger.ts";
 
 test({
@@ -19,7 +19,7 @@ test({
     await logger.debug(denops, "foo", "bar");
 
     const messages = await vimFuncs.execute(denops, "messages");
-    assertString(messages);
+    assert(messages, is.String);
     assertMatch(messages, /\n\[detect-indent\] foo bar/);
   },
 });
@@ -33,7 +33,7 @@ test({
     await logger.info(denops, "foo", "bar");
 
     const messages = await vimFuncs.execute(denops, "messages");
-    assertString(messages);
+    assert(messages, is.String);
     assertMatch(messages, /\n\[detect-indent\] foo bar/);
   },
 });
@@ -54,7 +54,7 @@ test({
       await logger.info(denops, "foo", "bar");
 
       const messages = await vimFuncs.execute(denops, "messages");
-      assertString(messages);
+      assert(messages, is.String);
       assertMatch(messages, /\n\[detect-indent\] foo bar/);
     }
   },
@@ -76,7 +76,7 @@ test({
       await logger.info(denops, "foo", "bar");
 
       const messages = await vimFuncs.execute(denops, "messages");
-      assertString(messages);
+      assert(messages, is.String);
       assertNotMatch(messages, /\n\[detect-indent\] foo bar/);
     }
   },
@@ -91,7 +91,7 @@ test({
     await logger.warn(denops, "foo", "bar");
 
     const messages = await vimFuncs.execute(denops, "messages");
-    assertString(messages);
+    assert(messages, is.String);
     assertMatch(messages, /\n\[detect-indent\] foo bar/);
   },
 });
@@ -112,7 +112,7 @@ test({
       await logger.warn(denops, "foo", "bar");
 
       const messages = await vimFuncs.execute(denops, "messages");
-      assertString(messages);
+      assert(messages, is.String);
       assertMatch(messages, /\n\[detect-indent\] foo bar/);
     }
   },
@@ -134,7 +134,7 @@ test({
       await logger.warn(denops, "foo", "bar");
 
       const messages = await vimFuncs.execute(denops, "messages");
-      assertString(messages);
+      assert(messages, is.String);
       assertNotMatch(messages, /\n\[detect-indent\] foo bar/);
     }
   },
@@ -149,7 +149,7 @@ test({
     await logger.error(denops, "foo", "bar");
 
     const messages = await vimFuncs.execute(denops, "messages");
-    assertString(messages);
+    assert(messages, is.String);
     assertMatch(messages, /\n\[detect-indent\] foo bar/);
   },
 });

--- a/test/denops/detect-indent/options_test.ts
+++ b/test/denops/detect-indent/options_test.ts
@@ -1,8 +1,8 @@
 // Use denops' test() instead of built-in Deno.test()
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as options from "../../../denops/detect-indent/options.ts";
 
 test({

--- a/test/denops/detect-indent/options_test.ts
+++ b/test/denops/detect-indent/options_test.ts
@@ -1,19 +1,28 @@
 // Use denops' test() instead of built-in Deno.test()
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import { assertType } from "https://deno.land/std@0.192.0/testing/types.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
-import * as options from "../../../denops/detect-indent/options.ts";
+import type {
+  Options,
+  OptionsAsEmpty,
+  OptionsAsExpandtab,
+  OptionsAsNonExpandtab,
+} from "../../../denops/detect-indent/options.ts";
+import {
+  isOptions,
+  set as setOptions,
+} from "../../../denops/detect-indent/options.ts";
 
 test({
   mode: "all",
-  name:
-    "options.set() sets `expandtab` and `shiftwidth` when both of them are given",
+  name: "set() sets `expandtab` and `shiftwidth` when both of them are given",
   async fn(denops: Denops) {
     await vimOptions.expandtab.set(denops, false);
     await vimOptions.shiftwidth.set(denops, 8);
 
-    await options.set(denops, { expandtab: true, shiftwidth: 2 });
+    await setOptions(denops, { expandtab: true, shiftwidth: 2 });
 
     assertEquals(await vimOptions.expandtab.get(denops), true);
     assertEquals(await vimOptions.shiftwidth.get(denops), 2);
@@ -22,12 +31,12 @@ test({
 
 test({
   mode: "all",
-  name: "options.set() sets only `expandtab` when `shiftwidth` is missing",
+  name: "set() sets only `expandtab` when `shiftwidth` is missing",
   async fn(denops: Denops) {
     await vimOptions.expandtab.set(denops, true);
     await vimOptions.shiftwidth.set(denops, 8);
 
-    await options.set(denops, { expandtab: false });
+    await setOptions(denops, { expandtab: false });
 
     assertEquals(await vimOptions.expandtab.get(denops), false);
     assertEquals(await vimOptions.shiftwidth.get(denops), 8);
@@ -36,14 +45,70 @@ test({
 
 test({
   mode: "all",
-  name: "options.set() does nothing when the argument is empty",
+  name: "set() does nothing when the argument is empty",
   async fn(denops: Denops) {
     await vimOptions.expandtab.set(denops, false);
     await vimOptions.shiftwidth.set(denops, 8);
 
-    await options.set(denops, {});
+    await setOptions(denops, {});
 
     assertEquals(await vimOptions.expandtab.get(denops), false);
     assertEquals(await vimOptions.shiftwidth.get(denops), 8);
+  },
+});
+
+Deno.test({
+  name: "isOptions() returns true if the argument is a Options",
+  fn() {
+    const nonExpandtabOptions: OptionsAsNonExpandtab = { expandtab: false };
+    const expandtabOptions: OptionsAsExpandtab = {
+      expandtab: true,
+      shiftwidth: 2,
+    };
+    const emptyOptions: OptionsAsEmpty = {};
+
+    assertType<typeof nonExpandtabOptions extends Options ? true : false>(true);
+    assertType<typeof expandtabOptions extends Options ? true : false>(true);
+    assertType<typeof emptyOptions extends Options ? true : false>(true);
+
+    assertEquals(isOptions(nonExpandtabOptions), true);
+    assertEquals(isOptions(expandtabOptions), true);
+    assertEquals(isOptions(emptyOptions), true);
+  },
+});
+
+Deno.test({
+  name: "isOptions() returns false unless the argument is a Options",
+  fn() {
+    const withOnlyUnknownKeys = { foo: 42 };
+    const withInvalidExpandtab = { expandtab: 42 };
+    const expandtabButWithoutShiftwidth: { expandtab: true } = {
+      expandtab: true,
+    };
+    const expandtabButWithInvalidShiftwidth: {
+      expandtab: true;
+      shiftwidth: "";
+    } = {
+      expandtab: true,
+      shiftwidth: "",
+    };
+
+    assertType<
+      typeof withOnlyUnknownKeys extends Options ? true : false
+    >(false);
+    assertType<
+      typeof withInvalidExpandtab extends Options ? true : false
+    >(false);
+    assertType<
+      typeof expandtabButWithoutShiftwidth extends Options ? true : false
+    >(false);
+    assertType<
+      typeof expandtabButWithInvalidShiftwidth extends Options ? true : false
+    >(false);
+
+    assertEquals(isOptions(withOnlyUnknownKeys), false);
+    assertEquals(isOptions(withInvalidExpandtab), false);
+    assertEquals(isOptions(expandtabButWithoutShiftwidth), false);
+    assertEquals(isOptions(expandtabButWithInvalidShiftwidth), false);
   },
 });

--- a/test/denops/detect-indent/restore_test.ts
+++ b/test/denops/detect-indent/restore_test.ts
@@ -4,10 +4,10 @@ import {
   assertEquals,
   assertMatch,
 } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v5.0.0/mod.ts";
-import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.0/function/mod.ts";
-import * as vimOptions from "https://deno.land/x/denops_std@v5.0.0/option/mod.ts";
-import { assertString } from "https://deno.land/x/unknownutil@v2.1.1/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
+import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
+import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
+import { assertString } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import * as bufferCache from "../../../denops/detect-indent/buffer-cache.ts";
 import { restore } from "../../../denops/detect-indent/restore.ts";
 

--- a/test/denops/detect-indent/restore_test.ts
+++ b/test/denops/detect-indent/restore_test.ts
@@ -7,7 +7,7 @@ import {
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
-import { assertString } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
+import { assert, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
 import * as bufferCache from "../../../denops/detect-indent/buffer-cache.ts";
 import { restore } from "../../../denops/detect-indent/restore.ts";
 
@@ -48,7 +48,7 @@ test({
     assertEquals(await vimOptions.shiftwidth.get(denops), 2);
 
     const messages = await vimFuncs.execute(denops, "messages");
-    assertString(messages);
+    assert(messages, is.String);
     assertMatch(
       messages,
       /\n\[detect-indent\] Indentation previously not detected\/set yet\./,


### PR DESCRIPTION
```sh
$ make update-deps
```

```
deno run --allow-all https://deno.land/x/udd/main.ts $(find . -type f -name '*.ts' -not -path '*.deno/*' -not -path '*test/fixtures/*')
/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/detectable.ts
[1/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/5] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[2/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/batch/mod.ts
[2/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/batch/mod.ts -> v5.0.1
[2/5] Update successful: https://deno.land/x/denops_std@v5.0.0/batch/mod.ts -> v5.0.1
[3/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[3/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[3/5] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[4/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts
[4/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[4/5] Update successful: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[5/5] Looking for releases: https://deno.land/x/unknownutil@v2.1.1/mod.ts
[5/5] Attempting update: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0
[5/5] Update successful: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/util.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/detect.ts
[1/1] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/1] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/restore.ts
[1/1] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/1] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/options.ts
[1/2] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/2] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/2] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[2/2] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[2/2] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/logger.ts
[1/3] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/3] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/3] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[2/3] Looking for releases: https://deno.land/x/denops_std@v5.0.0/batch/mod.ts
[2/3] Attempting update: https://deno.land/x/denops_std@v5.0.0/batch/mod.ts -> v5.0.1
[2/3] Update successful: https://deno.land/x/denops_std@v5.0.0/batch/mod.ts -> v5.0.1
[3/3] Looking for releases: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts
[3/3] Attempting update: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[3/3] Update successful: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/main.ts
[1/1] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/1] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/1] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/calculate.ts
[1/2] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/2] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/2] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[2/2] Looking for releases: https://deno.land/x/denops_std@v5.0.0/function/mod.ts
[2/2] Attempting update: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[2/2] Update successful: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/buffer-cache.ts
[1/4] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[1/4] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[1/4] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[2/4] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[2/4] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[2/4] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[3/4] Looking for releases: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts
[3/4] Attempting update: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[3/4] Update successful: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[4/4] Looking for releases: https://deno.land/x/unknownutil@v2.1.1/mod.ts
[4/4] Attempting update: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0
[4/4] Update successful: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/test-helper.ts
[1/1] Looking for releases: https://deno.land/std@0.192.0/path/mod.ts
[1/1] Using latest: https://deno.land/std@0.192.0/path/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/options_test.ts
[1/4] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/4] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/4] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/4] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts
[3/4] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[3/4] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[3/4] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[4/4] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[4/4] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[4/4] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/logger_test.ts
[1/6] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/6] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/6] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/6] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts
[3/6] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[3/6] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[3/6] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[4/6] Looking for releases: https://deno.land/x/denops_std@v5.0.0/function/mod.ts
[4/6] Attempting update: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[4/6] Update successful: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[5/6] Looking for releases: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts
[5/6] Attempting update: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[5/6] Update successful: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[6/6] Looking for releases: https://deno.land/x/unknownutil@v2.1.1/mod.ts
[6/6] Attempting update: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0
[6/6] Update successful: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/restore_test.ts
[1/6] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/6] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/6] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/6] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts
[3/6] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[3/6] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[3/6] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[4/6] Looking for releases: https://deno.land/x/denops_std@v5.0.0/function/mod.ts
[4/6] Attempting update: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[4/6] Update successful: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[5/6] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[5/6] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[5/6] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[6/6] Looking for releases: https://deno.land/x/unknownutil@v2.1.1/mod.ts
[6/6] Attempting update: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0
[6/6] Update successful: https://deno.land/x/unknownutil@v2.1.1/mod.ts -> v3.2.0

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/util_test.ts
[1/1] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[1/1] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/calculate_test.ts
[1/4] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/4] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/4] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/4] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts
[3/4] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[3/4] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[3/4] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[4/4] Looking for releases: https://deno.land/x/denops_std@v5.0.0/function/mod.ts
[4/4] Attempting update: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[4/4] Update successful: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/detectable_test.ts
[1/5] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/5] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/5] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/5] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts
[3/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[3/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[3/5] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[4/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[4/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[4/5] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[5/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts
[5/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[5/5] Update successful: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/detect_test.ts
[1/5] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/5] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/5] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/5] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts
[3/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[3/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[3/5] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[4/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/function/mod.ts
[4/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[4/5] Update successful: https://deno.land/x/denops_std@v5.0.0/function/mod.ts -> v5.0.1
[5/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[5/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[5/5] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/buffer-cache_test.ts
[1/5] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/5] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/5] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/5] Using latest: https://deno.land/std@0.192.0/testing/asserts.ts
[3/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/mod.ts
[3/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[3/5] Update successful: https://deno.land/x/denops_std@v5.0.0/mod.ts -> v5.0.1
[4/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/option/mod.ts
[4/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[4/5] Update successful: https://deno.land/x/denops_std@v5.0.0/option/mod.ts -> v5.0.1
[5/5] Looking for releases: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts
[5/5] Attempting update: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1
[5/5] Update successful: https://deno.land/x/denops_std@v5.0.0/variable/mod.ts -> v5.0.1

Already latest version:
https://deno.land/std@0.192.0/path/mod.ts == 0.192.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/std@0.192.0/testing/asserts.ts == 0.192.0

Successfully updated:
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/batch/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/variable/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/unknownutil@v2.1.1/mod.ts v2.1.1 -> v3.2.0
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/batch/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/variable/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/function/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/variable/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/unknownutil@v2.1.1/mod.ts v2.1.1 -> v3.2.0
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/function/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/variable/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/unknownutil@v2.1.1/mod.ts v2.1.1 -> v3.2.0
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/function/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/unknownutil@v2.1.1/mod.ts v2.1.1 -> v3.2.0
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/function/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/variable/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/function/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/option/mod.ts v5.0.0 -> v5.0.1
https://deno.land/x/denops_std@v5.0.0/variable/mod.ts v5.0.0 -> v5.0.1
make cache
make[1]: Entering directory '/home/runner/work/vim-detect-indent/vim-detect-indent'
deno cache $(find . -type f -name '*.ts' -not -path '*.deno/*' -not -path '*test/fixtures/*')
make[1]: Leaving directory '/home/runner/work/vim-detect-indent/vim-detect-indent'
make fmt
make[1]: Entering directory '/home/runner/work/vim-detect-indent/vim-detect-indent'
deno fmt --ignore='.deno/,test/fixtures/'
make[1]: Leaving directory '/home/runner/work/vim-detect-indent/vim-detect-indent'

```