### PR TITLE
Update Deno Dependencies

### DIFF
--- a/test/denops/detect-indent/buffer-cache_test.ts
+++ b/test/denops/detect-indent/buffer-cache_test.ts
@@ -3,8 +3,8 @@ import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import { assertType } from "https://deno.land/std@0.192.0/testing/types.ts";
+} from "https://deno.land/std@0.193.0/testing/asserts.ts";
+import { assertType } from "https://deno.land/std@0.193.0/testing/types.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";

--- a/test/denops/detect-indent/calculate_test.ts
+++ b/test/denops/detect-indent/calculate_test.ts
@@ -1,6 +1,6 @@
 // Use denops' test() instead of built-in Deno.test()
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.193.0/testing/asserts.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import { calculate } from "../../../denops/detect-indent/calculate.ts";

--- a/test/denops/detect-indent/detect_test.ts
+++ b/test/denops/detect-indent/detect_test.ts
@@ -3,7 +3,7 @@ import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import {
   assertEquals,
   assertNotEquals,
-} from "https://deno.land/std@0.192.0/testing/asserts.ts";
+} from "https://deno.land/std@0.193.0/testing/asserts.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";

--- a/test/denops/detect-indent/detectable_test.ts
+++ b/test/denops/detect-indent/detectable_test.ts
@@ -3,7 +3,7 @@ import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.192.0/testing/asserts.ts";
+} from "https://deno.land/std@0.193.0/testing/asserts.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";

--- a/test/denops/detect-indent/logger_test.ts
+++ b/test/denops/detect-indent/logger_test.ts
@@ -3,7 +3,7 @@ import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import {
   assertMatch,
   assertNotMatch,
-} from "https://deno.land/std@0.192.0/testing/asserts.ts";
+} from "https://deno.land/std@0.193.0/testing/asserts.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import * as vimVars from "https://deno.land/x/denops_std@v5.0.1/variable/mod.ts";

--- a/test/denops/detect-indent/options_test.ts
+++ b/test/denops/detect-indent/options_test.ts
@@ -1,7 +1,7 @@
 // Use denops' test() instead of built-in Deno.test()
 import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
-import { assertType } from "https://deno.land/std@0.192.0/testing/types.ts";
+import { assertEquals } from "https://deno.land/std@0.193.0/testing/asserts.ts";
+import { assertType } from "https://deno.land/std@0.193.0/testing/types.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";
 import type {

--- a/test/denops/detect-indent/restore_test.ts
+++ b/test/denops/detect-indent/restore_test.ts
@@ -3,7 +3,7 @@ import { test } from "https://deno.land/x/denops_test@v1.4.0/mod.ts";
 import {
   assertEquals,
   assertMatch,
-} from "https://deno.land/std@0.192.0/testing/asserts.ts";
+} from "https://deno.land/std@0.193.0/testing/asserts.ts";
 import type { Denops } from "https://deno.land/x/denops_std@v5.0.1/mod.ts";
 import * as vimFuncs from "https://deno.land/x/denops_std@v5.0.1/function/mod.ts";
 import * as vimOptions from "https://deno.land/x/denops_std@v5.0.1/option/mod.ts";

--- a/test/denops/detect-indent/util_test.ts
+++ b/test/denops/detect-indent/util_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.192.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.193.0/testing/asserts.ts";
 import { isEmptyObject } from "../../../denops/detect-indent/util.ts";
 
 Deno.test({

--- a/test/denops/test-helper.ts
+++ b/test/denops/test-helper.ts
@@ -1,4 +1,4 @@
-import * as path from "https://deno.land/std@0.192.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.193.0/path/mod.ts";
 
 export const root = {
   toString(): string {


### PR DESCRIPTION
```sh
$ make update-deps
```

```
deno run --allow-all https://deno.land/x/udd/main.ts $(find . -type f -name '*.ts' -not -path '*.deno/*' -not -path '*test/fixtures/*')
/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/options.ts
[1/3] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/3] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[2/3] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[2/3] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[3/3] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts
[3/3] Using latest: https://deno.land/x/unknownutil@v3.2.0/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/restore.ts
[1/1] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/1] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/util.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/detectable.ts
[1/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/6] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[2/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/batch/mod.ts
[2/6] Using latest: https://deno.land/x/denops_std@v5.0.1/batch/mod.ts
[3/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[3/6] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[4/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[4/6] Using latest: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[5/6] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts
[5/6] Using latest: https://deno.land/x/unknownutil@v3.2.0/mod.ts
[6/6] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts
[6/6] Using latest: https://deno.land/x/unknownutil@v3.2.0/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/buffer-cache.ts
[1/4] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/4] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[2/4] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[2/4] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[3/4] Looking for releases: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[3/4] Using latest: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[4/4] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts
[4/4] Using latest: https://deno.land/x/unknownutil@v3.2.0/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/main.ts
[1/1] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/1] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/logger.ts
[1/3] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/3] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[2/3] Looking for releases: https://deno.land/x/denops_std@v5.0.1/batch/mod.ts
[2/3] Using latest: https://deno.land/x/denops_std@v5.0.1/batch/mod.ts
[3/3] Looking for releases: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[3/3] Using latest: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/calculate.ts
[1/2] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/2] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[2/2] Looking for releases: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[2/2] Using latest: https://deno.land/x/denops_std@v5.0.1/function/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/denops/detect-indent/detect.ts
[1/1] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[1/1] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/test-helper.ts
[1/1] Looking for releases: https://deno.land/std@0.192.0/path/mod.ts
[1/1] Attempting update: https://deno.land/std@0.192.0/path/mod.ts -> 0.193.0
[1/1] Update successful: https://deno.land/std@0.192.0/path/mod.ts -> 0.193.0

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/detectable_test.ts
[1/5] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/5] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/5] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/5] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[2/5] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[3/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[3/5] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[4/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[4/5] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[5/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[5/5] Using latest: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/restore_test.ts
[1/6] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/6] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/6] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/6] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[2/6] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[3/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[3/6] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[4/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[4/6] Using latest: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[5/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[5/6] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[6/6] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts
[6/6] Using latest: https://deno.land/x/unknownutil@v3.2.0/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/options_test.ts
[1/5] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/5] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/5] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/5] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[2/5] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[3/5] Looking for releases: https://deno.land/std@0.192.0/testing/types.ts
[3/5] Attempting update: https://deno.land/std@0.192.0/testing/types.ts -> 0.193.0
[3/5] Update successful: https://deno.land/std@0.192.0/testing/types.ts -> 0.193.0
[4/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[4/5] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[5/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[5/5] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/util_test.ts
[1/1] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[1/1] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[1/1] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/logger_test.ts
[1/6] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/6] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/6] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/6] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[2/6] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[3/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[3/6] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[4/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[4/6] Using latest: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[5/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[5/6] Using latest: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[6/6] Looking for releases: https://deno.land/x/unknownutil@v3.2.0/mod.ts
[6/6] Using latest: https://deno.land/x/unknownutil@v3.2.0/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/calculate_test.ts
[1/4] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/4] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/4] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/4] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[2/4] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[3/4] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[3/4] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[4/4] Looking for releases: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[4/4] Using latest: https://deno.land/x/denops_std@v5.0.1/function/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/buffer-cache_test.ts
[1/6] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/6] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/6] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/6] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[2/6] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[3/6] Looking for releases: https://deno.land/std@0.192.0/testing/types.ts
[3/6] Attempting update: https://deno.land/std@0.192.0/testing/types.ts -> 0.193.0
[3/6] Update successful: https://deno.land/std@0.192.0/testing/types.ts -> 0.193.0
[4/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[4/6] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[5/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[5/6] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[6/6] Looking for releases: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts
[6/6] Using latest: https://deno.land/x/denops_std@v5.0.1/variable/mod.ts

/home/runner/work/vim-detect-indent/vim-detect-indent/test/denops/detect-indent/detect_test.ts
[1/5] Looking for releases: https://deno.land/x/denops_test@v1.4.0/mod.ts
[1/5] Using latest: https://deno.land/x/denops_test@v1.4.0/mod.ts
[2/5] Looking for releases: https://deno.land/std@0.192.0/testing/asserts.ts
[2/5] Attempting update: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[2/5] Update successful: https://deno.land/std@0.192.0/testing/asserts.ts -> 0.193.0
[3/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/mod.ts
[3/5] Using latest: https://deno.land/x/denops_std@v5.0.1/mod.ts
[4/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[4/5] Using latest: https://deno.land/x/denops_std@v5.0.1/function/mod.ts
[5/5] Looking for releases: https://deno.land/x/denops_std@v5.0.1/option/mod.ts
[5/5] Using latest: https://deno.land/x/denops_std@v5.0.1/option/mod.ts

Already latest version:
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1
https://deno.land/x/unknownutil@v3.2.0/mod.ts == v3.2.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/batch/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/variable/mod.ts == v5.0.1
https://deno.land/x/unknownutil@v3.2.0/mod.ts == v3.2.0
https://deno.land/x/unknownutil@v3.2.0/mod.ts == v3.2.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/variable/mod.ts == v5.0.1
https://deno.land/x/unknownutil@v3.2.0/mod.ts == v3.2.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/batch/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/variable/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/function/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/variable/mod.ts == v5.0.1
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/function/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1
https://deno.land/x/unknownutil@v3.2.0/mod.ts == v3.2.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/function/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/variable/mod.ts == v5.0.1
https://deno.land/x/unknownutil@v3.2.0/mod.ts == v3.2.0
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/function/mod.ts == v5.0.1
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/variable/mod.ts == v5.0.1
https://deno.land/x/denops_test@v1.4.0/mod.ts == v1.4.0
https://deno.land/x/denops_std@v5.0.1/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/function/mod.ts == v5.0.1
https://deno.land/x/denops_std@v5.0.1/option/mod.ts == v5.0.1

Successfully updated:
https://deno.land/std@0.192.0/path/mod.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/types.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/types.ts 0.192.0 -> 0.193.0
https://deno.land/std@0.192.0/testing/asserts.ts 0.192.0 -> 0.193.0
make cache
make[1]: Entering directory '/home/runner/work/vim-detect-indent/vim-detect-indent'
deno cache $(find . -type f -name '*.ts' -not -path '*.deno/*' -not -path '*test/fixtures/*')
make[1]: Leaving directory '/home/runner/work/vim-detect-indent/vim-detect-indent'
make fmt
make[1]: Entering directory '/home/runner/work/vim-detect-indent/vim-detect-indent'
deno fmt --ignore='.deno/,test/fixtures/'
make[1]: Leaving directory '/home/runner/work/vim-detect-indent/vim-detect-indent'

```